### PR TITLE
Update the URL used for API Calls, links to documentions and how some tests resolve

### DIFF
--- a/PsGeotab/Classes/Classes.ps1
+++ b/PsGeotab/Classes/Classes.ps1
@@ -1,10 +1,9 @@
 <#
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.User
+https://developers.geotab.com/myGeotab/apiReference/objects/User
 #>
-class User
-{
+class User {
     [bool]$acceptedEULA
     [string]$activeDashboardReports
     [datetime]$activeFrom
@@ -21,26 +20,26 @@ class User
     [string]$companyName
     [string]$countryCode
     [string]$dateFormat = 'MM/dd/yy HH:mm:ss'
-    [ValidateSet(,'Hybrid','Roadmap','Satellite','Terrain')]
+    [ValidateSet(, 'Hybrid', 'Roadmap', 'Satellite', 'Terrain')]
     [string]$defaultGoogleMapStyle = 'Roadmap'
     [ValidateSet()]
     [object]$defaultHereMapStyle = 'Roadmap'
     [ValidateSet('GoogleMaps''HereMap''MapBox')]
     [string]$defaultMapEngine = 'MapBox'
-    [ValidateSet('Cycle','MapBox','None','Satellite','Transport')]
+    [ValidateSet('Cycle', 'MapBox', 'None', 'Satellite', 'Transport')]
     [string]$defaultOpenStreetMapStyle = 'MapBox'
     [string]$defaultPage
-    [ValidateRange(0,50)]
+    [ValidateRange(0, 50)]
     [string]$designation
     [int]$driveGuideVersion
-    [ValidateSet('KiloWhPer100Km','KiloWhPer100Miles','KmPerKiloWh','KmPerLitersE','LitersEPer100Km','MPGEImperial','MPGEUS','MilePerKiloWh','WhPerKm','WhPerMile')]
+    [ValidateSet('KiloWhPer100Km', 'KiloWhPer100Miles', 'KmPerKiloWh', 'KmPerLitersE', 'LitersEPer100Km', 'MPGEImperial', 'MPGEUS', 'MilePerKiloWh', 'WhPerKm', 'WhPerMile')]
     [string]$electricEnergyEconomyUnit = 'LitersEPer100Km'
-    [ValidateRange(0,50)]
+    [ValidateRange(0, 50)]
     [string]$employeeNo
     [object]$firstDayOfWeek = 'Sunday'
-    [ValidateRange(0,255)]
+    [ValidateRange(0, 255)]
     [string]$firstName
-    [ValidateSet('KmPerLiter','LitersPer100Km','MPGImperial','MPGUS')]
+    [ValidateSet('KmPerLiter', 'LitersPer100Km', 'MPGImperial', 'MPGUS')]
     [string]$fuelEconomyUnit = 'LitersPer100Km'
     [string]$hosRuleSet
     [string]$id
@@ -55,17 +54,17 @@ class User
     [boolean]$isServiceUpdatesEnabled
     [boolean]$isYardMoveEnabled
     [string]$language = 'en'
-    [ValidateRange(0,255)]
+    [ValidateRange(0, 255)]
     [string]$lastName
-    [ValidateSet('highlightGroups','name','viewport')]
+    [ValidateSet('highlightGroups', 'name', 'viewport')]
     [string[]]$mapViews
     [int]$maxPCDistancePerDay
-    [ValidateRange(0,255)]
+    [ValidateRange(0, 255)]
     [string]$name
     [string]$password
-    [ValidateRange(0,20)]
+    [ValidateRange(0, 20)]
     [string]$phoneNumber
-    [ValidateRange(0,5)]
+    [ValidateRange(0, 5)]
     [string]$phoneNumberExtension
     [string[]]$privateUserGroups
     [string[]]$reportGroups
@@ -73,7 +72,7 @@ class User
     [boolean]$showClickOnceWarning
     [string]$timeZoneId = 'America/New_York'
     [int]$wifiEULA
-    [ValidateSet('All','Default','None')]
+    [ValidateSet('All', 'Default', 'None')]
     [string]$zoneDisplayMode = 'Default'
     [string]$version
 }
@@ -81,10 +80,9 @@ class User
 <#
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.Driver
+https://developers.geotab.com/myGeotab/apiReference/objects/Driver
 #>
-class Driver : User
-{
+class Driver : User {
     [string[]]$driverGroups
     [string[]]$keys
     [string]$licenseNumber

--- a/PsGeotab/Public/Get-DateRange.ps1
+++ b/PsGeotab/Public/Get-DateRange.ps1
@@ -60,7 +60,7 @@ function Get-DateRange {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('activeFrom')]
         [datetime]$From,
 
@@ -87,43 +87,40 @@ function Get-DateRange {
         Write-Debug "StartOfMonth: $StartOfMonth"
         Write-Debug "EndOfMonth: $EndOfMonth"
     }
-    Process
-    {
+    Process {
         Write-Debug "$($MyInvocation.MyCommand.Name)::Process"
 
-        if ($ExcludeFuture) 
-        {
+        if ($ExcludeFuture) {
             $Today = (Get-Date)
             $To = if ( $Today.Date -lt $To.Date ) { $Today } else { $To }
         }
     
         $Save = $From
 
-        Write-Debug "$($From.Date) - $($To.Date)"
+        Write-Debug "From: $($From.Date) - To: $($To.Date)"
 
-        while ( $From.Date -le $To.Date ) 
-        {
+        while ( $From.Date -le $To.Date ) {
             if ($FirstDate -and $From.Date -eq $Save.Date) { $From.Date + $Time }
             elseif ($LastDate -and $From.Date -eq $To.Date) { $From.Date + $Time }
-            else
-            {
+            else {
+                Write-Debug "From:$($From), EOM: $($From.AddMonths(1).AddDays(-$From.Day).Date), $( $EndOfMonth -and (-not ($From.Month -eq 1) -or -not ($From.Month -eq 7)) -and ($From.Date -eq $From.AddMonths(1).AddDays(-$From.Day).Date))"
                 # -StartOfMonth and mm/1/yy
                 if ( $StartOfMonth -and $From.Day -eq 1) { $From.Date + $Time }
-                
+        
                 # -EndOfMonth and mm/[28|29|30|31]/yy
-                if ( $EndOfMonth -and $From.Date -eq $From.Date.AddDays(-$From.Day).AddMonths(1) ) { $From.Date + $Time }
-
+                if ( $EndOfMonth -and (!($From.Month -eq 1)) -and ($From.Date -eq $From.AddMonths(1).AddDays(-$From.Day).Date)) { $From.Date + $Time }
+                if ($EndOfMonth -and $From.Day -eq 31 -and !($From.Month -eq 7)) { $From.Date + $Time }
+        
                 # -StartOfMonth and -EndOfMonth not supplied
                 elseif ( !$StartOfMonth -and !$EndOfMonth ) { $From.Date + $Time }
             }
-
             # increment
             $From = $From.AddDays(1)
+        
         }
     
     }
-    End 
-    { 
+    End { 
         Write-Debug "$($MyInvocation.MyCommand.Name)::End"
     }
 

--- a/PsGeotab/Public/Get-Diagnostic.ps1
+++ b/PsGeotab/Public/Get-Diagnostic.ps1
@@ -10,27 +10,26 @@ Vehicle diagnostic information from the engine computer that can either be measu
 Diagnostics cannot be added, set or removed via the API.
 
 .LINK
-https://my41.geotab.com/Lorenz/#engineMeasurements,dateRange:(endDate:'2020-01-16T05:59:59.000Z',startDate:'2020-01-15T06:00:00.000Z'),devices:all,diagnostics:!(DiagnosticThirdPartyOdometerId,DiagnosticOdometerId),groupBy:diagnostic
+https://developers.geotab.com/myGeotab/apiReference/objects/Diagnostic
 
 #>
 function Get-Diagnostic {
 
-    [CmdletBinding()]
-    param(
+	[CmdletBinding()]
+	param(
 		
 		[Parameter(Mandatory = $true)]
-        [PsCustomObject]$Session,
+		[PsCustomObject]$Session,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName=$true, ValueFromPipeline=$true)]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
 		[Alias('id')]
-        [string[]]$DeviceId
+		[string[]]$DeviceId
 
-        # [ValidateSet('DataDiagnostic')]
-        # [string]$DiagnosisType
-    )
+		# [ValidateSet('DataDiagnostic')]
+		# [string]$DiagnosisType
+	)
 
-	Begin
-	{
+	Begin {
 		Write-Debug "$($MyInvocation.MyCommand.Name)::Begin"
 
 		$Uri = "https://$($Session.path)/apiv1"
@@ -40,21 +39,19 @@ function Get-Diagnostic {
 		$Body = @{
 			method = 'Get'
 			params = @{ 
-				typeName = 'Diagnostic'
+				typeName    = 'Diagnostic'
 				credentials = $Session.credentials
-				search = @{
+				search      = @{
 					diagnosticType = ''
 				}
 			}
 		}
 
 	}
-	Process
-	{
+	Process {
 		Write-Debug "$($MyInvocation.MyCommand.Name)::Process"
 	
-		foreach ($Id in $DeviceId) 
-		{
+		foreach ($Id in $DeviceId) {
 			Write-Debug "DeviceId: $Id"
 
 			# remove search key and value
@@ -62,7 +59,7 @@ function Get-Diagnostic {
 
 			# add a search
 			if ($Id) {
-				$Body['params']['search'] = @{id = $Id}
+				$Body['params']['search'] = @{id = $Id }
 			}
 			# elseif ($DiagnosisType) {
 			# 	$Body['params']['search'] = @{diagnosticType = $DiagnosisType}
@@ -81,8 +78,7 @@ function Get-Diagnostic {
 		}
 
 	}
-	End
-	{
+	End {
 		Write-Debug "$($MyInvocation.MyCommand.Name)::End"
 	}
 

--- a/PsGeotab/Public/Get-GeotabDeviceType.ps1
+++ b/PsGeotab/Public/Get-GeotabDeviceType.ps1
@@ -16,7 +16,7 @@ Get all devices.
 PS> Get-GeotabDeviceType
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.DeviceType
+https://developers.geotab.com/myGeotab/apiReference/objects/DeviceType
 
 #>
 function Get-GeotabDeviceType {

--- a/PsGeotab/Public/Get-GeotabDiagnosticType.ps1
+++ b/PsGeotab/Public/Get-GeotabDiagnosticType.ps1
@@ -16,13 +16,13 @@ Get all devices.
 PS> Get-GeotabDiagnosticType
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.DiagnosticType
+https://developers.geotab.com/myGeotab/apiReference/objects/DiagnosticType
 
 #>
 function Get-GeotabDiagnosticType {
 
     $csv = `
-@"
+        @"
 Name,Description
 BrpFault,BRP Fault.
 DataDiagnostic,Data Diagnostic.

--- a/PsGeotab/Public/Get-GeotabEntity.ps1
+++ b/PsGeotab/Public/Get-GeotabEntity.ps1
@@ -58,10 +58,10 @@ function Get-GeotabEntity {
         $Body['params'].Add('search', $search)
     }
 
-    Write-Debug ($Body | ConvertTo-Json)
+    Write-Debug ($Body | ConvertTo-Json -Depth 5)
 
     # POST
-    $Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json) -ContentType "application/json" ).Content | ConvertFrom-Json
+    $Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json -Depth 5) -ContentType "application/json" ).Content | ConvertFrom-Json
 
     # returns PsCustomObject representation of object
     if ( $Content.result ) { $Content.result }

--- a/PsGeotab/Public/Get-GeotabEntity.ps1
+++ b/PsGeotab/Public/Get-GeotabEntity.ps1
@@ -1,32 +1,54 @@
+<#
+.SYNOPSIS
+Get Geotab Entities such as a Device or User
+
+.PARAMETER Session
+
+.PARAMETER typeName
+
+.PARAMETER resultsLimit
+limit the results to an integer
+
+.PARAMETER search
+Get Method search object
+
+.NOTES
+Returns the Entities based on the TypeName and Seach objects provided
+
+.LINK
+https://developers.geotab.com/myGeotab/apiReference/methods/Get
+
+#>
+
 function Get-GeotabEntity {
 
     [CmdletBinding()]
-	param
-	(
-		[Parameter(Mandatory)]
-		[PsCustomObject]$Session,
+    param
+    (
+        [Parameter(Mandatory)]
+        [PsCustomObject]$Session,
 
         [Parameter(Mandatory)]
-		[string]$typeName,
+        [string]$typeName,
 
         [Parameter()]
         [int]$resultsLimit,
 
         [Parameter()]
         [object]$search
-	)
+    )
 
-	$Uri = "https://$($Session.path)/apiv1"
-	Write-Debug "Uri: $Uri"
+    $Uri = "https://$($Session.path)/apiv1"
+    Write-Debug "Uri: $Uri"
 	
-	# payload as JSON
-	$Body = @{
+    # payload as JSON
+    $Body = @{
         method = 'Get'
         params = @{ 
             credentials = $Session.credentials
-            typeName = $typeName
+            typeName    = $typeName
         }
-	}
+    }
 
     if ( $PsBoundParameters['resultsLimit'] ) {
         $Body['params'].Add('resultsLimit', $resultsLimit)
@@ -36,14 +58,14 @@ function Get-GeotabEntity {
         $Body['params'].Add('search', $search)
     }
 
-	Write-Debug ($Body | ConvertTo-Json)
+    Write-Debug ($Body | ConvertTo-Json)
 
-	# POST
-	$Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json) -ContentType "application/json" ).Content | ConvertFrom-Json
+    # POST
+    $Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json) -ContentType "application/json" ).Content | ConvertFrom-Json
 
-	# returns PsCustomObject representation of object
-	if ( $Content.result ) { $Content.result }
-	# otherwise raise an exception
+    # returns PsCustomObject representation of object
+    if ( $Content.result ) { $Content.result }
+    # otherwise raise an exception
     elseif ($Content.error) { Write-Error -Message $Content.error.message }
 
 }

--- a/PsGeotab/Public/Get-GeotabEntityType.ps1
+++ b/PsGeotab/Public/Get-GeotabEntityType.ps1
@@ -16,7 +16,7 @@ Get all devices.
 PS> Get-GeotabEntityType
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.Entity
+https://developers.geotab.com/myGeotab/apiReference/objects/Entity
 #>
 function Get-GeotabEntityType {
 
@@ -24,6 +24,8 @@ function Get-GeotabEntityType {
     param ()
     
     @(
+        'A1'
+        'AddInData'
         'AnnotationLog'
         'Audit'
         'BinaryPayload'
@@ -34,6 +36,7 @@ function Get-GeotabEntityType {
         'DataDiagnostic'
         'DebugData'
         'Device'
+        'DeviceShare'
         'DeviceStatusInfo'
         'Diagnostic'
         'DistributionList'
@@ -46,9 +49,10 @@ function Get-GeotabEntityType {
         'ExceptionEvent'
         'FailureMode'
         'FaultData'
+        'FillUp'
         'FlashCode'
-        'FuelEvent'
         'FuelTaxDetail'
+        'FuelUsed'
         'FuelTransaction'
         'Go4v3'
         'Go5'
@@ -56,6 +60,7 @@ function Get-GeotabEntityType {
         'Go7'
         'Go8'
         'Go9'
+        'Go9B'
         'GoCurve'
         'GoCurveAuxiliary'
         'GoDevice'
@@ -63,6 +68,7 @@ function Get-GeotabEntityType {
         'GroupSecurity'
         'IoxAddOn'
         'LogRecord'
+        'MediaFile'
         'ParameterGroup'
         'Recipient'
         'RequestLocation'
@@ -73,16 +79,18 @@ function Get-GeotabEntityType {
         'ShipmentLog'
         'Source'
         'StatusData'
+        'TachographDataFile'
         'TextMessage'
         'Trailer'
         'TrailerAttachment'
         'Trip'
         'UnitOfMeasure'
         'User'
+        'WifiHotspot'
         'WorkHoliday'
         'WorkTime'
         'WorkTimeDetail'
-        'Zone'   
+        'Zone'
     )
 
 }

--- a/PsGeotab/Public/New-GeotabDeviceSearch.ps1
+++ b/PsGeotab/Public/New-GeotabDeviceSearch.ps1
@@ -36,7 +36,7 @@ Search for a Device by Vehicle Identification Number (VIN). This is the unique n
 Search for an entry based on the specific Id.
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.DeviceSearch
+https://developers.geotab.com/myGeotab/apiReference/objects/DeviceSearch
 
 #>
 function New-GeotabDeviceSearch {

--- a/PsGeotab/Public/New-GeotabDiagnosticSearch.ps1
+++ b/PsGeotab/Public/New-GeotabDiagnosticSearch.ps1
@@ -18,7 +18,7 @@ The SourceSearch Id to search for in Diagnostics. Available SourceSearch options
 Search for an entry based on the specific Id.
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.Engine.DiagnosticSearch
+https://developers.geotab.com/myGeotab/apiReference/objects/Engine.DiagnosticSearch
 
 #>
 function New-GeotabDiagnosticSearch {

--- a/PsGeotab/Public/New-GeotabSession.ps1
+++ b/PsGeotab/Public/New-GeotabSession.ps1
@@ -31,11 +31,10 @@ PS> New-GeotabSession -Database 'database' -Credential $Credential
 Create a new Geotab session, supplying parameters in code.
 
 .LINK
-https://geotab.github.io/sdk/software/guides/concepts/#authentication
+https://developers.geotab.com/MyGeotab/software/guides/concepts/#authentication
 
 #>
-function New-GeotabSession
-{
+function New-GeotabSession {
 	[CmdletBinding()]
 	param
 	(
@@ -56,7 +55,7 @@ function New-GeotabSession
 	Write-Debug "Database: $Database"
 	Write-Debug "UserName: $($Credential.UserName)"
 
-	$Headers = @{'Cache-Control' = 'no-cache'}
+	$Headers = @{'Cache-Control' = 'no-cache' }
 
 	# payload as JSON
 	$body = @{
@@ -77,7 +76,12 @@ function New-GeotabSession
 	$Content = ( Invoke-WebRequest -Uri $Uri -Method Post -Body $Body -ContentType "application/json" -Headers $Headers ).Content | ConvertFrom-Json
 
 	# returns PsCustomObject representation of credentials
-	if ( $Content.result ) { [PsCustomObject]$Content.result }
+	if ( $Content.result ) { 
+		if ($Content.result.Path -eq 'ThisServer') {
+			$Content.result.Path = 'my.geotab.com'
+		}
+		[PsCustomObject]$Content.result 
+	}
 
 	# otherwise raise an exception
 	elseif ($Content.error) { Write-Error -Message $Content.error.message }

--- a/PsGeotab/Public/New-GeotabUserSearch.ps1
+++ b/PsGeotab/Public/New-GeotabUserSearch.ps1
@@ -42,7 +42,7 @@ Search for Users that were active at this date or before.
 Search for an entry based on the specific Id.
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.UserSearch
+https://developers.geotab.com/myGeotab/apiReference/objects/UserSearch
 #>
 
 function New-GeotabUserSearch {

--- a/PsGeotab/Public/Search-FuelTaxDetail.ps1
+++ b/PsGeotab/Public/Search-FuelTaxDetail.ps1
@@ -20,7 +20,7 @@ A value indicating whether to include hourly data.
 Search for an entry based on the specific Id.  NOT the deviceId.
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.FuelTaxDetailSearch
+https://developers.geotab.com/myGeotab/apiReference/objects/FuelTaxDetailSearch
 
 #>
 function Search-FuelTaxDetail {
@@ -56,9 +56,9 @@ function Search-FuelTaxDetail {
     $Body = @{
         method = 'Get'
         params = @{ 
-            typeName = 'FuelTaxDetail'
+            typeName    = 'FuelTaxDetail'
             credentials = $Session.credentials
-            search = @{}
+            search      = @{}
         }
     }
 

--- a/PsGeotab/Public/Search-StatusData.ps1
+++ b/PsGeotab/Public/Search-StatusData.ps1
@@ -25,17 +25,17 @@ Get DiagnosticOdometerAdjustmentId diagnostics for device `b57` that occurred to
 When searching for status data including DeviceSearch and DiagnosticSearch the system will return all records that match the search criteria and interpolate the value at the provided from/to dates when there is no record that corresponds to the date. Interpolated records are dynamically created when the request is made and can be identified as not having the ID property populated. Records with an ID are stored in the database.
 
 .LINK
-https://geotab.github.io/sdk/software/api/reference/#T:Geotab.Checkmate.ObjectModel.Engine.StatusDataSearch
+https://developers.geotab.com/myGeotab/apiReference/objects/Engine.StatusDataSearch
 
 #>
 function Search-StatusData {
 
     [CmdletBinding()]
     param(
-		[Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [PsCustomObject]$Session,
 
-        [Parameter(ValueFromPipelineByPropertyName,ValueFromPipeline)]
+        [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline)]
         [Alias('id')]
         [string]$DeviceId,
     
@@ -47,11 +47,10 @@ function Search-StatusData {
         [Alias('activeTo')]
         [datetime]$ToDate = [DateTime]::Today.AddDays(1).AddSeconds(-1),
 
-        [string]$DiagnosticId='DiagnosticOdometerAdjustmentId'
+        [string]$DiagnosticId = 'DiagnosticOdometerAdjustmentId'
     )
 
-    Begin
-    {
+    Begin {
         Write-Debug "$($MyInvocation.MyCommand.Name)::Begin"
 
         $Uri = "https://$($Session.path)/apiv1"
@@ -59,40 +58,39 @@ function Search-StatusData {
 
         Write-Debug "DiagnosticId: $DiagnosticId"
     }
-    Process
-    {
+    Process {
         Write-Debug "$($MyInvocation.MyCommand.Name)::Process"
 
         # foreach ($Id in $DeviceId) 
         # {
-            Write-Debug "DeviceId: $DeviceId"
-            Write-Debug "FromDate: $FromDate"
-            Write-Debug "ToDate: $ToDate"
+        Write-Debug "DeviceId: $DeviceId"
+        Write-Debug "FromDate: $FromDate"
+        Write-Debug "ToDate: $ToDate"
     
-            # payload as JSON
-            $Body = @{
-                method = 'Get'
-                params = @{ 
-                    typeName = 'StatusData'
-                    credentials = $Session.credentials
-                    search = @{
-                        deviceSearch = @{ id = $DeviceId }
-                        diagnosticSearch = @{ id = $DiagnosticId }
-                        fromDate = $FromDate.ToUniversalTime().ToString("o")
-                        toDate = $toDate.ToUniversalTime().ToString("o")
-                    }
+        # payload as JSON
+        $Body = @{
+            method = 'Get'
+            params = @{ 
+                typeName    = 'StatusData'
+                credentials = $Session.credentials
+                search      = @{
+                    deviceSearch     = @{ id = $DeviceId }
+                    diagnosticSearch = @{ id = $DiagnosticId }
+                    fromDate         = $FromDate.ToUniversalTime().ToString("o")
+                    toDate           = $toDate.ToUniversalTime().ToString("o")
                 }
-            } 
+            }
+        } 
 
-            # Write-Debug ($Body | ConvertTo-Json -Depth 3)
+        # Write-Debug ($Body | ConvertTo-Json -Depth 3)
 
-            # POST
-            $Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json -Depth 3 ) -ContentType "application/json" ).Content | ConvertFrom-Json
+        # POST
+        $Content = ( Invoke-WebRequest -Uri $uri -Method Post -Body ($Body | ConvertTo-Json -Depth 3 ) -ContentType "application/json" ).Content | ConvertFrom-Json
 
-            # returns PsCustomObject representation of object
-            if ( $Content.result ) { $Content.result }
-            # otherwise raise an exception
-            elseif ($Content.error) { Write-Error -Message $Content.error.message }
+        # returns PsCustomObject representation of object
+        if ( $Content.result ) { $Content.result }
+        # otherwise raise an exception
+        elseif ($Content.error) { Write-Error -Message $Content.error.message }
                     
         # } # /foreach
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ PS> Get-ChildItem -Path . -Recurse | Unblock-File
 # create a session using the credentials and database provided by Geotab
 PS> $Session = Get-Session -Database 'Database' -Credential (Get-Credential)
 ```
-### Get-Device
+### Get-GeotabEntity - Device
 
 ```powershell
 # search for a device by the `Name` property
-PS> Get-Device -Session $Session -name '80012%' | 
+PS> Get-GeotabEntity -Session $Session -typeName 'Device' -search @{name = '80012%' } | 
 
     # choosing specific properties
     Select-Object vehicleIdentificationNumber, licensePlate, name, vehicleIdentificationNumber, id, serialNumber, deviceType, activeFrom, activeTo | 
@@ -65,13 +65,13 @@ PS> Get-Device -Session $Session -name '80012%' |
     # save it to a file on the current user's desktop
     Out-File "~/Desktop/com.geotab.devices.csv"
 ```
-### Get-Device
+### Get-GeotabEntity - Device + StatusData
 
 #### Get the most-recent odometer readings that occured today.
 
 ```powershell
 # get all devices
-PS> Get-Device -Session $Session |
+PS> Get-GeotabEntity -Session $Session -typeName 'Device' |
 
     # search diagnostics using defalt parameters
     Search-StatusData -Session $Session | 
@@ -107,7 +107,7 @@ PS> Get-Device -Session $Session |
 $Session = Get-Session ...
 
 # get a list of devices
-Get-Device -Session $Session | 
+Get-GeotabEntity -Session $Session -typeName 'Device' | 
 
 # select the device's `id` property
 Select-Object id |
@@ -133,7 +133,7 @@ Format-Table
 # rather than this
 PS> $Session = Get-Session -Database 'Database' -Credential (Get-Credential)
 
-PS> Get-Device -Session $Session | Search-StatusData -Session $Session | ...
+PS> Get-GeotabEntity -Session $Session -typeName 'Device' | Search-StatusData -Session $Session | ...
 
 # do this
 PS> $Session = Get-Session -Database 'Database' -Credential (Get-Credential)

--- a/Tests/Private/ConvertTo-PlainText.Tests.ps1
+++ b/Tests/Private/ConvertTo-PlainText.Tests.ps1
@@ -14,45 +14,46 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . (Join-Path $PrivatePath $sut)
 
 Describe "ConvertTo-PlainText" -tag 'Unit' {
+    InModuleScope PsGeotab {
+        # dummy password
+        $Expected = 'Pa55w0rd'
 
-    # dummy password
-    $Expected = 'Pa55w0rd'
+        # create SecureString
+        $SecureString = ConvertTo-SecureString $Expected -AsPlainText -Force
 
-    # create SecureString
-    $SecureString = ConvertTo-SecureString $Expected -AsPlainText -Force
+        # create a PsCredential
+        $Credential = New-Object System.Management.Automation.PSCredential ("LoremIpsum", $SecureString)
 
-    # create a PsCredential
-    $Credential = New-Object System.Management.Automation.PSCredential ("LoremIpsum", $SecureString)
+        Context "SecureString provided by named parameter" {
 
-    Context "SecureString provided by named parameter" {
+            It "converts the value to 'plain' text" {
+                # act
+                $Actual = ConvertTo-PlainText -SecureString $Credential.Password
 
-        It "converts the value to 'plain' text" {
-            # act
-            $Actual = ConvertTo-PlainText -SecureString $Credential.Password
-
-            # assert
-            $Actual | Should -Be $Expected
+                # assert
+                $Actual | Should -Be $Expected
+            }
         }
-    }
 
-    Context "SecureString supplied via pipeline" {
-        It "converts the value to 'plain' text" {
-            # act
-            $Actual = $Credential.Password | ConvertTo-PlainText 
+        Context "SecureString supplied via pipeline" {
+            It "converts the value to 'plain' text" {
+                # act
+                $Actual = $Credential.Password | ConvertTo-PlainText 
 
-            # assert
-            $Actual | Should -Be $Expected
+                # assert
+                $Actual | Should -Be $Expected
+            }
         }
-    }
 
-    Context "SecureString supplied via pipeline by name" {        
-        It "converts the value to 'plain' text" {
-            # act
-            $Actual = $Credential | ConvertTo-PlainText 
+        Context "SecureString supplied via pipeline by name" {        
+            It "converts the value to 'plain' text" {
+                # act
+                $Actual = $Credential | ConvertTo-PlainText 
 
-            # assert
-            $Actual | Should -Be $Expected
+                # assert
+                $Actual | Should -Be $Expected
+            }
         }
-    }
 
+    }
 }

--- a/Tests/Public/Get-DateRange.Tests.ps1
+++ b/Tests/Public/Get-DateRange.Tests.ps1
@@ -13,14 +13,21 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 # . /PsGeotab/PsGeotab/Public/Get-DataRange.ps1
 . (Join-Path $PublicPath $sut)
 
+BeforeDiscovery {
+    
+    [datetime]$From = '2024-01-01'
+    [datetime]$To = '2024-01-31'
+}
+
 Describe "Get-DateRange" {
 
-    [datetime]$From = '01/01/2019'
-    [datetime]$To = '01/31/2019'
-
-    Context "`$From and `$To supplied" {
-
-        It "generates dates between `$From and `$To" {
+    Context "<From> and <To> supplied" {
+        BeforeEach {
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = '2024-01-31'
+        }
+        
+        It "generates dates between <From> and <To>" {
 
             # act
             $Actual = Get-DateRange $From $To
@@ -33,13 +40,15 @@ Describe "Get-DateRange" {
     
     }
 
-    Context "`$From date supplied" {
+    Context "<From> date supplied" {
 
-        # arrange
-        [datetime]$From = '01/01/2020'
-        [datetime]$To = (Get-Date).Date
+        BeforeEach {
+            # arrange
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = (Get-Date).Date
+        }
 
-        It "generates dates between `$From and Today" {
+        It "generates dates between <From> and Today" {
 
             # act
             $Actual = Get-DateRange $From
@@ -53,14 +62,16 @@ Describe "Get-DateRange" {
     
     }
 
-    Context "`$From and `$To supplied via pipeline" {
+    Context "<From> and <To> supplied via pipeline" {
 
-        $Hash = [PsCustomObject]@{
-            activeFrom=[datetime]'01/01/2020'
-            activeTo=[datetime]'01/05/2020'
+        BeforeEach {
+            $Hash = [PsCustomObject]@{
+                activeFrom = [datetime]'2024-01-01'
+                activeTo   = [datetime]'2024-01-05'
+            }
         }
 
-        It "generates dates between `$From and `$To" {
+        It "generates dates between <From> and <To>" {
 
             # act
             $Actual = $Hash | Get-DateRange
@@ -74,12 +85,13 @@ Describe "Get-DateRange" {
     } # /context
 
     Context "-ExcludeFuture supplied" {
-
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = (Get-Date).AddDays(10)
+        BeforeEach {
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = (Get-Date).AddDays(10)
         
-        $Expected = (Get-Date).Date
-
+        
+            $Expected = (Get-Date).Date
+        }
         It "Generates dates that are <= Today" {
 
             # act
@@ -94,10 +106,10 @@ Describe "Get-DateRange" {
     } # /context
 
     Context "-StartOfMonth supplied" {
-
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = '02/15/2019'
-    
+        BeforeEach {
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = '2024-02-15'
+        }
         It "Generates dates that are the first of the month" {
 
             # act
@@ -105,17 +117,17 @@ Describe "Get-DateRange" {
 
             # assert
             $Actual | Select-Object -First 1 | Should -Be $From
-            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'02/01/2019')
+            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-02-01')
             $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
 
         }
     } # /context
 
-    Context "`$StartOfMonth and `$ExcludeFuture supplied" {
-
-        [datetime]$From = (get-date -day 1).addmonths(-1).date # first of the month, one month ago
-        [datetime]$To = (Get-Date).AddMonths(2)
-        
+    Context "<Star>tOfMonth and <Excl>udeFuture supplied" {
+        BeforeEach {
+            [datetime]$From = (get-date -day 1).addmonths(-1).date # first of the month, one month ago
+            [datetime]$To = (Get-Date).AddMonths(2)
+        }
         It "Generates dates that are <= Today and are first of the month" {
 
             # act
@@ -130,64 +142,64 @@ Describe "Get-DateRange" {
     } # /context
 
     Context "-EndOfMonth supplied" {
-
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = '03/15/2019'
-    
-        It "Generates dates that are the last of the month" {
+        BeforeEach {
+            [datetime]$From = '2024-03-01'
+            [datetime]$To = '2024-05-15'
+        }
+        It "Generates dates that are the last of the month of <From>" {
 
             # act
             $Actual = Get-DateRange -From $From -To $To -EndOfMonth
 
             # assert
-            $Actual | Select-Object -First 1 | Should -Be ([datetime]'01/31/2019')
-            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'02/28/2019')
+            $Actual | Select-Object -First 1 | Should -Be ([datetime]'2024-03-31')
+            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-04-30')
             $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
 
         }
     } # /context
 
-    Context "`$StartOfMonth and `$EndOfMonth supplied" {
-
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = '03/15/2019'
-    
+    Context "<Star>tOfMonth and <EndO>fMonth supplied" {
+        BeforeEach {
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = '2024-03-15'
+        }
         It "Generates dates that are the first and last of the month" {
 
             # act
             $Actual = Get-DateRange -From $From -To $To -StartOfMonth -EndOfMonth
 
             # assert
-            $Actual | Select-Object -First 1 | Should -Be ([datetime]'01/01/2019')
-            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'03/01/2019')
+            $Actual | Select-Object -First 1 | Should -Be ([datetime]'2024-01-01')
+            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-03-01')
             $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 5
 
         }
     } # /context
 
-    Context "`$StartOfMonth and `$EndOfMonth and `$ExcludeFuture supplied" {
-
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = '03/15/2019'
-    
+    Context "<Star>tOfMonth and <EndO>fMonth and <Excl>udeFuture supplied" {
+        BeforeEach {
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = '2024-03-15'
+        }
         It "Generates dates that are the first and last of the month and are <= Today" {
 
             # act
             $Actual = Get-DateRange -From $From -To $To -StartOfMonth -EndOfMonth -ExcludeFuture
 
             # assert
-            $Actual | Select-Object -First 1 | Should -Be ([datetime]'01/01/2019')
-            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'03/01/2019')
+            $Actual | Select-Object -First 1 | Should -Be ([datetime]'2024-01-01')
+            $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-03-01')
             $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 5
 
         }
     } # /context
 
     Context "-FirstDate supplied" {
-
-        [datetime]$From = '01/03/2019'
-        [datetime]$To = '02/15/2019'
-
+        BeforeEach {
+            [datetime]$From = '2024-01-03'
+            [datetime]$To = '2024-02-15'
+        }
         Context "-StartOfMonth supplied" {
     
             It "Includes the first record and the first day of the month" {
@@ -197,7 +209,7 @@ Describe "Get-DateRange" {
     
                 # assert
                 $Actual | Select-Object -First 1 | Should -Be $From
-                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'02/01/2019')
+                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-02-01')
                 $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
 
             }
@@ -213,7 +225,7 @@ Describe "Get-DateRange" {
     
                 # assert
                 $Actual | Select-Object -First 1 | Should -Be $From
-                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'01/31/2019')
+                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-01-31')
                 $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
     
             }
@@ -225,18 +237,18 @@ Describe "Get-DateRange" {
     Context "-LastDate supplied" {
     
         Context "-StartOfMonth supplied" {
-
-            [datetime]$From = '01/15/2019'
-            [datetime]$To = '02/15/2019'
-    
+            BeforeEach {
+                [datetime]$From = '2024-01-15'
+                [datetime]$To = '2024-02-15'
+            }
             It "Includes the last record and the first day of the month" {
 
                 # act
                 $Actual = Get-DateRange -From $From -To $To -LastDate -StartOfMonth
     
                 # assert
-                $Actual | Select-Object -First 1 | Should -Be ([datetime]'02/01/2019')
-                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'02/15/2019')
+                $Actual | Select-Object -First 1 | Should -Be ([datetime]'2024-02-01')
+                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-02-15')
                 $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
 
             }
@@ -244,18 +256,18 @@ Describe "Get-DateRange" {
         }
 
         Context "-EndOfMonth supplied" {
-
-            [datetime]$From = '01/15/2019'
-            [datetime]$To = '02/15/2019'
-
+            BeforeEach {
+                [datetime]$From = '2024-01-15'
+                [datetime]$To = '2024-02-15'
+            }
             It "Includes the last record and the last day of the month" {
 
                 # act
                 $Actual = Get-DateRange -From $From -To $To -LastDate -EndOfMonth
     
                 # assert
-                $Actual | Select-Object -First 1 | Should -Be ([datetime]'01/31/2019')
-                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'02/15/2019')
+                $Actual | Select-Object -First 1 | Should -Be ([datetime]'2024-01-31')
+                $Actual | Select-Object -Last 1 | Should -Be ([datetime]'2024-02-15')
                 $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 2
     
             }
@@ -265,18 +277,18 @@ Describe "Get-DateRange" {
     } # /context
 
     Context "-Time 23:59:59" {
-
-        $Time = '23:59:59'
-        [datetime]$From = '01/01/2019'
-        [datetime]$To = '01/01/2019'
-
+        BeforeEach {
+            $Time = '23:59:59'
+            [datetime]$From = '2024-01-01'
+            [datetime]$To = '2024-01-01'
+        }
         It "Adds $Time to the date" {
 
             # act
             $Actual = Get-DateRange -From $From -To $To -Time $Time
 
             # assert
-            $Actual | Select-Object -First 1 | Should -Be ([datetime]"01/01/2019 $Time")
+            $Actual | Select-Object -First 1 | Should -Be ([datetime]"2024-01-01 $Time")
             $Actual | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 1
 
         }

--- a/Tests/Public/Get-GeotabEntity.Tests.ps1
+++ b/Tests/Public/Get-GeotabEntity.Tests.ps1
@@ -85,7 +85,7 @@ Describe "Get-GeotabEntity" -Tag 'unit' {
         BeforeAll {
             # arrange
             $Session = [PsCustomObject]@{
-                path = 'servername'
+                path        = 'servername'
                 credentials = [PsCustomObject]@{
                     sessionId = 123456
                 }

--- a/Tests/Public/New-GeotabDeviceSearch.Tests.ps1
+++ b/Tests/Public/New-GeotabDeviceSearch.Tests.ps1
@@ -21,13 +21,13 @@ Describe "New-GeotabDeviceSearch" -Tag 'unit' {
         $Expected = [pscustomobject]@{
             comments = '%comments%'
             deviceType = 'device type'
-            fromDate = '03/01/2020 12:00:00'
+            fromDate = '2024-03-01 12:00:00'
             groups = '1,2,3'
             keywords = 'keywords'
             licensePlate = '%ABC123%'
             name = '%name%'
             serialNumber = 'ABCEDFGHIJKLMNOPQRSTUVWXYZ'
-            toDate = '03/31/2020 23:59:59'
+            toDate = '2024-03-31 23:59:59'
             vehicleIdentificationNumber = '0123456789'
             id = 'b1234'
         }

--- a/Tests/Public/New-GeotabUserSearch.Tests.ps1
+++ b/Tests/Public/New-GeotabUserSearch.Tests.ps1
@@ -33,7 +33,7 @@ Describe "New-GeotabUserSearch" -Tag 'unit' {
         }
 
         Context 'driverGroup' {
-            BeforeAll { $ParameterName = 'driverGroup'}
+            BeforeAll { $ParameterName = 'driverGroup' }
 
             It "is a [String[]]" {
                 $Command | Should -HaveParameter $ParameterName -Type string[]
@@ -173,18 +173,18 @@ Describe "New-GeotabUserSearch" -Tag 'unit' {
 
             # arrange
             $Expected = [pscustomobject]@{
-                companyGroup = 'companyGroup'
-                firstName = 'firstName'
-                lastName = 'lastName'
-                name = 'name'
-                fromDate = '07/22/2020 20:00:00'
-                toDate = '07/22/2020 21:00:00'
-                isDriver = $true
-                keyId = 'keyId'
-                keywords = 'keywords'
+                companyGroup  = 'companyGroup'
+                firstName     = 'firstName'
+                lastName      = 'lastName'
+                name          = 'name'
+                fromDate      = '2024-07-22 20:00:00'
+                toDate        = '2024-07-22 21:00:00'
+                isDriver      = $true
+                keyId         = 'keyId'
+                keywords      = 'keywords'
                 securityGroup = 'securityGroup'
-                serialNumber = 'serialNumber'
-                id = 'b1234'
+                serialNumber  = 'serialNumber'
+                id            = 'b1234'
             }
 
         }
@@ -219,18 +219,18 @@ Describe "New-GeotabUserSearch" -Tag 'unit' {
 
             # arrange
             $Expected = [pscustomobject]@{
-                driverGroup = 'driverGroup'
-                firstName = 'firstName'
-                lastName = 'lastName'
-                name = 'name'
-                fromDate = '07/22/2020 20:00:00'
-                toDate = '07/22/2020 21:00:00'
-                isDriver = $true
-                keyId = 'keyId'
-                keywords = 'keywords'
+                driverGroup   = 'driverGroup'
+                firstName     = 'firstName'
+                lastName      = 'lastName'
+                name          = 'name'
+                fromDate      = '2024-07-22 20:00:00'
+                toDate        = '2024-07-22 21:00:00'
+                isDriver      = $true
+                keyId         = 'keyId'
+                keywords      = 'keywords'
                 securityGroup = 'securityGroup'
-                serialNumber = 'serialNumber'
-                id = 'b1234'
+                serialNumber  = 'serialNumber'
+                id            = 'b1234'
             }
 
         }

--- a/Tests/Public/Search-FuelTaxDetail.Tests.ps1
+++ b/Tests/Public/Search-FuelTaxDetail.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Search-FuelTaxDetail" {
     } # /context
 
     $Session = [PsCustomObject]@{
-        path = 'servername'
+        path        = 'servername'
         credentials = [PsCustomObject]@{
             sessionId = 123456
         }
@@ -42,7 +42,7 @@ Describe "Search-FuelTaxDetail" {
     Mock Invoke-WebRequest {
 
         $Content = 
-@"
+        @"
 {
     "result": [
         {
@@ -102,13 +102,13 @@ Describe "Search-FuelTaxDetail" {
 
         it "creates correct request" {
             # arrange
-            $DeviceSearch = New-DeviceSearch -Id 'b65'
+            $DeviceSearch = New-GeotabDeviceSearch -Id 'b65'
 
             # act 
             $DeviceSearch | Search-FuelTaxDetail -Session $Session
 
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and
@@ -131,7 +131,7 @@ Describe "Search-FuelTaxDetail" {
             Search-FuelTaxDetail -Session $Session -FromDate $FromDate
     
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and
@@ -154,7 +154,7 @@ Describe "Search-FuelTaxDetail" {
             Search-FuelTaxDetail -Session $Session -ToDate $ToDate
    
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and
@@ -174,7 +174,7 @@ Describe "Search-FuelTaxDetail" {
             Search-FuelTaxDetail -Session $Session -IncludeBoundaries
 
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and
@@ -193,7 +193,7 @@ Describe "Search-FuelTaxDetail" {
             Search-FuelTaxDetail -Session $Session -IncludeHourlyData
 
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and
@@ -215,7 +215,7 @@ Describe "Search-FuelTaxDetail" {
             Search-FuelTaxDetail -Session $Session -Id $Id
 
             # assert
-            Assert-MockCalled Invoke-WebRequest -ParameterFilter {
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
                 $X = $Body | ConvertFrom-Json
 
                 $Uri -eq "https://$($Session.path)/apiv1" -and


### PR DESCRIPTION
This PR resolve the following issues: 

- The [LoginResult](https://developers.geotab.com/myGeotab/apiReference/objects/LoginResult) property Path may return as `ThisServer` and not a URI. If Path is `ThisServer` the URI <my.geotab.com> is  used instead.
- The Get-Date range produced some odd results when the `-StartOfMonth` and/or `-EndOfMonth` when the From date incremented to some months, usually January and August for some reaons. 
- Links to the old documentation website have been updated where I was able to find them.

- Updated some to the tests have been added for better success with the changes to Pester v5. 
  - I can't find out how to update the Invoke ones to Mock correctly, as such some of them fail but functions do work 

Tests Passed: 93, Failed: 10, Skipped: 2, Inconclusive: 0, NotRun: 0
 - Search-FuelTaxDetail
 - New-GeotabUserSearch
 - Get-GeotabEntity